### PR TITLE
BREAKING Refactor KeyBehavior

### DIFF
--- a/src/behavior/KeyBehaviorManager.java
+++ b/src/behavior/KeyBehaviorManager.java
@@ -3,6 +3,7 @@ package behavior;
 
 import behavior.behaviors.KeyBehavior;
 import game.Element;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 import java.util.HashSet;
@@ -10,30 +11,29 @@ import java.util.Set;
 
 /**
  * Deze class is verantwoordelijk voor het afhandelen van KeyBehavoir.
- * */
+ */
 public class KeyBehaviorManager implements BehaviorManager {
 
-    private Stage stage;
+    private Scene scene;
     private Set<String> keyCodes;
 
     public KeyBehaviorManager(Stage stage) {
-        this.stage = stage;
+        this.scene = stage.getScene();
         keyCodes = new HashSet<>();
         setupKeyConfig();
     }
 
     private void setupKeyConfig() {
-        this.stage.getScene().setOnKeyPressed(event -> {
-            keyCodes.add(event.getCode().toString());
-        });
-        stage.getScene().setOnKeyReleased(event -> keyCodes.remove(event.getCode().toString()));
+        scene.setOnKeyPressed(event -> keyCodes.add(event.getCode().toString()));
+        scene.setOnKeyReleased(event -> keyCodes.remove(event.getCode().toString()));
     }
 
 
     /**
      * Geeft aan dat er een Key event afgehandel moet worden door een element met een KeyBehavior uit het spel.
+     *
      * @param element met KeyBehavior.
-     * */
+     */
     @Override
     public void handle(Element element) {
         KeyBehavior keyBehavior = (KeyBehavior) element;

--- a/src/behavior/KeyBehaviorManager.java
+++ b/src/behavior/KeyBehaviorManager.java
@@ -3,11 +3,10 @@ package behavior;
 
 import behavior.behaviors.KeyBehavior;
 import game.Element;
-import javafx.event.EventHandler;
-import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 
-import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Deze class is verantwoordelijk voor het afhandelen van KeyBehavoir.
@@ -15,30 +14,19 @@ import java.util.ArrayList;
 public class KeyBehaviorManager implements BehaviorManager {
 
     private Stage stage;
-    private ArrayList<String> keyCodes;
+    private Set<String> keyCodes;
 
     public KeyBehaviorManager(Stage stage) {
         this.stage = stage;
-        keyCodes = new ArrayList<>();
+        keyCodes = new HashSet<>();
         setupKeyConfig();
     }
 
     private void setupKeyConfig() {
-        this.stage.getScene().setOnKeyPressed(new EventHandler<KeyEvent>() {
-            @Override
-            public void handle(KeyEvent event) {
-                if(!keyCodes.contains(event.getCode().toString())){
-                    keyCodes.add(event.getCode().toString());
-                }
-
-            }
+        this.stage.getScene().setOnKeyPressed(event -> {
+            keyCodes.add(event.getCode().toString());
         });
-        stage.getScene().setOnKeyReleased(new EventHandler<KeyEvent>() {
-            @Override
-            public void handle(KeyEvent event) {
-                keyCodes.remove(event.getCode().toString());
-            }
-        });
+        stage.getScene().setOnKeyReleased(event -> keyCodes.remove(event.getCode().toString()));
     }
 
 

--- a/src/behavior/behaviors/KeyBehavior.java
+++ b/src/behavior/behaviors/KeyBehavior.java
@@ -2,7 +2,7 @@ package behavior.behaviors;
 
 import behavior.Behavior;
 
-import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * Een behavoir specifiek voor key gerelateerde events.
@@ -13,5 +13,5 @@ public interface KeyBehavior extends Behavior {
      * Deze methode handeld een key event af.
      * @param keyCodes de keycodes die gebruikt zijn.
      * */
-    void handleKeyPresses(ArrayList<String> keyCodes);
+    void handleKeyPresses(Set<String> keyCodes);
 }


### PR DESCRIPTION
Refactor Keybehavior to use a Set instead of a List. Sets are more suited for what we need it for.